### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# global owners for nimi-python
+* @sbethur @marcoskirsch


### PR DESCRIPTION
This file describes code owners for the repo

created and added as described in: https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners

Enables adding owners as reviewers automatically.

### What testing has been done?

no specific testing. it should "just work" :) 